### PR TITLE
feat: allow disabling gps

### DIFF
--- a/custom_components/weenect/select.py
+++ b/custom_components/weenect/select.py
@@ -16,7 +16,7 @@ from custom_components.weenect.services import async_set_update_interval
 from .const import DOMAIN, TRACKER_ADDED
 from .entity import WeenectEntity
 
-SELECT_OPTIONS = ("30S", "1M", "5M", "10M", "30M", "60M")
+SELECT_OPTIONS = ("0S", "30S", "1M", "5M", "10M", "30M", "60M")
 DEFAULT_SELECT_OPTION = "30M"
 
 SELECT_ENTITY_DESCRIPTIONS: tuple[SelectEntityDescription, ...] = (

--- a/custom_components/weenect/services.yaml
+++ b/custom_components/weenect/services.yaml
@@ -13,6 +13,7 @@ set_update_interval:
       selector:
         select:
           options:
+            - "0S"
             - "30S"
             - "1M"
             - "5M"

--- a/custom_components/weenect/translations/de.json
+++ b/custom_components/weenect/translations/de.json
@@ -32,7 +32,7 @@
           "fields": {
             "update_interval": {
               "name": "Update Intervall",
-              "description": "Mögliche Werte sind: 30S 1M 5M 10M 30M 1H"
+              "description": "\"0S\" schaltet das Tracking aus"
             },
             "entity_id": {
                 "name": "Entity",

--- a/custom_components/weenect/translations/en.json
+++ b/custom_components/weenect/translations/en.json
@@ -32,7 +32,7 @@
           "fields": {
             "update_interval": {
               "name": "Update Interval",
-              "description": "Possible values are: 30S 1M 5M 10M 30M 1H"
+              "description": "\"0S\" disables tracking"
             },
             "entity_id": {
                 "name": "Entity",


### PR DESCRIPTION
https://github.com/eifinger/hass-weenect/pull/283 contains multiple changes and is stale for more than half a year now because of missing tests. Disabling the GPS is a quick win though and could easily be merged. I created a dedicated PR for that mere feature so it can be included.

I'll try to implement the remaining features in further dedicated PRs (and will incl. the required tests).