### PR TITLE
Update intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Set the tracker update interval. Disable tracking by setting interval to 0S.
 
 Name | Description | Example
 -- | -- | --
-`update_interval` | `The update interval. Possible values are 0S, 30S, 1M, 2M, 3M, 5M, 10M, 30M, 60M. Please note, that 30M and 60M are not officially supported in the Weenect app.` | `10M`
+`update_interval` | `The GPS update interval. Possible values are 0S, 30S, 1M, 2M, 3M, 5M, 10M, 30M, 60M. 0S disables tracking. Battery life will be low for 30S and 1M, high for 2M and 3M and medium for 5M and 10M. Please note, that 30M and 60M are not officially supported in the Weenect app.` | `10M`
 
 ### weenect.activate_super_live
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Set the tracker update interval. Disable tracking by setting interval to 0S.
 
 Name | Description | Example
 -- | -- | --
-`update_interval` | `The GPS update interval. Possible values are 0S, 30S, 1M, 2M, 3M, 5M, 10M, 30M, 60M. 0S disables tracking. Battery life will be low for 30S and 1M, high for 2M and 3M and medium for 5M and 10M. Please note, that 30M and 60M are not officially supported in the Weenect app.` | `10M`
+`update_interval` | `The GPS update interval. Possible values are 0S, 30S, 1M, 2M, 3M, 5M, 10M. 0S disables tracking. Battery life will be low for 30S and 1M, high for 2M and 3M and medium for 5M and 10M.` | `10M`
 
 ### weenect.activate_super_live
 
@@ -109,8 +109,8 @@ automation:
         data:
           update_interval: "1M"
   - id: 652b4b69-c951-4861-8b7d-3cbb15fc8b79
-    alias: "Setze Nayas Tracker Updaterate auf 60M wenn wir zu Hause sind"
-    description: "Set Nayas tracker update rate to 60m when we are at home"
+    alias: "Setze Nayas Tracker Updaterate auf 0S wenn wir zu Hause sind"
+    description: "Set Nayas tracker update rate to 0s (disable tracking) when we are at home"
     mode: single
     initial_state: true
     trigger:
@@ -123,7 +123,7 @@ automation:
         target:
           entity_id: device_tracker.naya
         data:
-          update_interval: "60M"
+          update_interval: "0S"
 ````
 
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Set the tracker update interval. Disable tracking by setting interval to 0S.
 
 Name | Description | Example
 -- | -- | --
-`update_interval` | `The update interval. Possible values are 0S 30S 1M 5M 10M 30M 1H.` | `30M`
+`update_interval` | `The update interval. Possible values are 0S, 30S, 1M, 2M, 3M, 5M, 10M, 30M, 60M. Please note, that 30M and 60M are not officially supported in the Weenect app.` | `10M`
 
 ### weenect.activate_super_live
 

--- a/custom_components/weenect/select.py
+++ b/custom_components/weenect/select.py
@@ -16,8 +16,8 @@ from custom_components.weenect.services import async_set_update_interval
 from .const import DOMAIN, TRACKER_ADDED
 from .entity import WeenectEntity
 
-SELECT_OPTIONS = ("0S", "30S", "1M", "5M", "10M", "30M", "60M")
-DEFAULT_SELECT_OPTION = "30M"
+SELECT_OPTIONS = ("0S", "30S", "1M", "2M", "3M", "5M", "10M", "30M", "60M")
+DEFAULT_SELECT_OPTION = "10M"
 
 SELECT_ENTITY_DESCRIPTIONS: tuple[SelectEntityDescription, ...] = (
     SelectEntityDescription(

--- a/custom_components/weenect/select.py
+++ b/custom_components/weenect/select.py
@@ -16,7 +16,7 @@ from custom_components.weenect.services import async_set_update_interval
 from .const import DOMAIN, TRACKER_ADDED
 from .entity import WeenectEntity
 
-SELECT_OPTIONS = ("0S", "30S", "1M", "2M", "3M", "5M", "10M", "30M", "60M")
+SELECT_OPTIONS = ("0S", "30S", "1M", "2M", "3M", "5M", "10M")
 DEFAULT_SELECT_OPTION = "10M"
 
 SELECT_ENTITY_DESCRIPTIONS: tuple[SelectEntityDescription, ...] = (

--- a/custom_components/weenect/services.py
+++ b/custom_components/weenect/services.py
@@ -11,7 +11,7 @@ DOMAIN_SERVICES = f"{DOMAIN}_services"
 
 SERVICE_SET_UPDATE_INTERVAL_SCHEMA = cv.make_entity_service_schema(
     {
-        vol.Optional(UPDATE_INTERVAL, default="30M"): cv.string,
+        vol.Optional(UPDATE_INTERVAL, default="10M"): cv.string,
     }
 )
 

--- a/custom_components/weenect/services.yaml
+++ b/custom_components/weenect/services.yaml
@@ -8,18 +8,20 @@ set_update_interval:
   fields:
     update_interval:
       required: true
-      example: "30M"
-      default: "30M"
+      example: "10M"
+      default: "10M"
       selector:
         select:
           options:
             - "0S"
             - "30S"
             - "1M"
+            - "2M"
+            - "3M"
             - "5M"
             - "10M"
             - "30M"
-            - "1H"
+            - "60M"
 
 activate_super_live:
   target:

--- a/custom_components/weenect/services.yaml
+++ b/custom_components/weenect/services.yaml
@@ -20,8 +20,6 @@ set_update_interval:
             - "3M"
             - "5M"
             - "10M"
-            - "30M"
-            - "60M"
 
 activate_super_live:
   target:

--- a/info.md
+++ b/info.md
@@ -33,7 +33,7 @@ Set the tracker update interval.
 
 Name | Description | Example
 -- | -- | --
-`update_interval` | `The update interval. Possible values are 30S 1M 5M 10M 30M 1H.` | `30M`
+`update_interval` | `The update interval. Possible values are 0S, 30S, 1M, 2M, 3M, 5M, 10M, 30M, 60M. Please note, that 30M and 60M are not officially supported in the Weenect app.` | `10M`
 
 ### weeenct.activate_super_live
 

--- a/info.md
+++ b/info.md
@@ -33,7 +33,7 @@ Set the tracker update interval.
 
 Name | Description | Example
 -- | -- | --
-`update_interval` | `The GPS update interval. Possible values are 0S, 30S, 1M, 2M, 3M, 5M, 10M, 30M, 60M. 0S disables tracking. Battery life will be low for 30S and 1M, high for 2M and 3M and medium for 5M and 10M. Please note, that 30M and 60M are not officially supported in the Weenect app.` | `10M`
+`update_interval` | `The GPS update interval. Possible values are 0S, 30S, 1M, 2M, 3M, 5M, 10M. 0S disables tracking. Battery life will be low for 30S and 1M, high for 2M and 3M and medium for 5M and 10M.` | `10M`
 
 ### weenect.activate_super_live
 
@@ -75,8 +75,8 @@ automation:
         data:
           update_interval: "1M"
   - id: 652b4b69-c951-4861-8b7d-3cbb15fc8b79
-    alias: "Setze Nayas Tracker Updaterate auf 60M wenn wir zu Hause sind"
-    description: "Set Nayas tracker update rate to 60m when we are at home"
+    alias: "Setze Nayas Tracker Updaterate auf 0S wenn wir zu Hause sind"
+    description: "Set Nayas tracker update rate to 0s (disable tracking) when we are at home"
     mode: single
     initial_state: true
     trigger:
@@ -89,7 +89,7 @@ automation:
         target:
           entity_id: device_tracker.naya
         data:
-          update_interval: "60M"
+          update_interval: "0S"
 ````
 
 <a href="https://www.buymeacoffee.com/eifinger" target="_blank"><img src="https://www.buymeacoffee.com/assets/img/custom_images/black_img.png" alt="Buy Me A Coffee" style="height: auto !important;width: auto !important;" ></a><br>

--- a/info.md
+++ b/info.md
@@ -33,7 +33,7 @@ Set the tracker update interval.
 
 Name | Description | Example
 -- | -- | --
-`update_interval` | `The update interval. Possible values are 0S, 30S, 1M, 2M, 3M, 5M, 10M, 30M, 60M. Please note, that 30M and 60M are not officially supported in the Weenect app.` | `10M`
+`update_interval` | `The GPS update interval. Possible values are 0S, 30S, 1M, 2M, 3M, 5M, 10M, 30M, 60M. 0S disables tracking. Battery life will be low for 30S and 1M, high for 2M and 3M and medium for 5M and 10M. Please note, that 30M and 60M are not officially supported in the Weenect app.` | `10M`
 
 ### weenect.activate_super_live
 

--- a/info.md
+++ b/info.md
@@ -27,7 +27,7 @@ Platform | Description
 
 ## Services
 
-### weeenct.set_update_interval
+### weenect.set_update_interval
 
 Set the tracker update interval.
 
@@ -35,19 +35,19 @@ Name | Description | Example
 -- | -- | --
 `update_interval` | `The update interval. Possible values are 0S, 30S, 1M, 2M, 3M, 5M, 10M, 30M, 60M. Please note, that 30M and 60M are not officially supported in the Weenect app.` | `10M`
 
-### weeenct.activate_super_live
+### weenect.activate_super_live
 
 Activate the super live mode.
 
-### weeenct.refresh_location
+### weenect.refresh_location
 
 Request a location update.
 
-### weeenct.ring
+### weenect.ring
 
 Let the tracker ring.
 
-### weeenct.vibrate
+### weenect.vibrate
 
 Let the tracker vibrate.
 


### PR DESCRIPTION
Once again changing intervals after having debugged the Weenect API and current app (Android and mobile web app). I can't tell though if there are different intervals for dog vs cat vs kid trackers. Furthermore I changed the default setting from `30M` to `10M` since that is the max. official interval and will show in the Android app' s UI.

Intervals that can be set through the apps:
`0S/30S/1M/2M/3M/5M/10M`

Intervals the API accepts:
`0S-99S` or `0M-99M`.

It is not possible to set hours (e.g. `1H`). I wasn't able to test if the tracker itself respects non official intervals (e.g. 13M, 60M, 99S) and would actually send the GPS signal at a non-official ("custom") interval. They are stored though server-side for the tracker and displayed in the mobile web app (since there is no slider to set the interval but rather a text display of the setting).

Furthermore I added battery life information from the mobile web app.

![image](https://github.com/eifinger/hass-weenect/assets/6610451/eaf82dac-cfa9-4704-aa35-0baae1742223)
![image](https://github.com/eifinger/hass-weenect/assets/6610451/61e61ba7-6de6-498a-adc6-df85a5bbf0a6)
![image](https://github.com/eifinger/hass-weenect/assets/6610451/a4e7622c-8c8e-458d-b1ab-eec25ecbc193)
![image](https://github.com/eifinger/hass-weenect/assets/6610451/9ca253ee-c951-44a5-add4-8c925f5b4438)
![image](https://github.com/eifinger/hass-weenect/assets/6610451/99794887-0036-4033-8c02-f68fe23435aa)
![image](https://github.com/eifinger/hass-weenect/assets/6610451/3f77a22b-1761-4663-902c-5f7a8ce19dc7)
