### PR TITLE
feat: add extra attributes to device_tracker

### DIFF
--- a/custom_components/weenect/device_tracker.py
+++ b/custom_components/weenect/device_tracker.py
@@ -170,3 +170,15 @@ class WeenectDeviceTracker(WeenectBaseEntity, TrackerEntity):
         if self.id in self.coordinator.data:
             if self.coordinator.data[self.id]["position"]:
                 return self.coordinator.data[self.id]["position"][0]["radius"]
+
+    @property
+    def extra_state_attributes(self):
+        """Return device specific attributes."""
+        if self.id in self.coordinator.data:
+            if self.coordinator.data[self.id]["position"]:
+                return {
+                    "speed": self.coordinator.data[self.id]["position"][0]["speed"],
+                    "course": self.coordinator.data[self.id]["position"][0]["direction"],
+                    "PDOP": self.coordinator.data[self.id]["position"][0]["pdop"],
+                    "confidence": self.coordinator.data[self.id]["position"][0]["confidence"]
+                }

--- a/custom_components/weenect/device_tracker.py
+++ b/custom_components/weenect/device_tracker.py
@@ -174,19 +174,17 @@ class WeenectDeviceTracker(WeenectBaseEntity, TrackerEntity):
     @property
     def extra_state_attributes(self):
         """Return device specific attributes."""
+        res = self._attr_extra_state_attributes
+
         if self.id in self.coordinator.data:
-            if (
-                self.coordinator.data[self.id]["id"]
-                and self.coordinator.data[self.id]["position"]
-            ):
-                return {
-                    "id": self.coordinator.data[self.id]["id"],
-                    "speed": self.coordinator.data[self.id]["position"][0]["speed"],
-                    "course": self.coordinator.data[self.id]["position"][0][
-                        "direction"
-                    ],
-                    "PDOP": self.coordinator.data[self.id]["position"][0]["pdop"],
-                    "confidence": self.coordinator.data[self.id]["position"][0][
-                        "confidence"
-                    ],
-                }
+            if self.coordinator.data[self.id]["position"]:
+                res["speed"] = self.coordinator.data[self.id]["position"][0]["speed"]
+                res["course"] = self.coordinator.data[self.id]["position"][0][
+                    "direction"
+                ]
+                res["PDOP"] = self.coordinator.data[self.id]["position"][0]["pdop"]
+                res["confidence"] = self.coordinator.data[self.id]["position"][0][
+                    "confidence"
+                ]
+
+        return res

--- a/custom_components/weenect/device_tracker.py
+++ b/custom_components/weenect/device_tracker.py
@@ -175,8 +175,12 @@ class WeenectDeviceTracker(WeenectBaseEntity, TrackerEntity):
     def extra_state_attributes(self):
         """Return device specific attributes."""
         if self.id in self.coordinator.data:
-            if self.coordinator.data[self.id]["position"]:
+            if (
+                self.coordinator.data[self.id]["id"]
+                and self.coordinator.data[self.id]["position"]
+            ):
                 return {
+                    "id": self.coordinator.data[self.id]["id"],
                     "speed": self.coordinator.data[self.id]["position"][0]["speed"],
                     "course": self.coordinator.data[self.id]["position"][0][
                         "direction"

--- a/custom_components/weenect/device_tracker.py
+++ b/custom_components/weenect/device_tracker.py
@@ -183,8 +183,5 @@ class WeenectDeviceTracker(WeenectBaseEntity, TrackerEntity):
                     "direction"
                 ]
                 res["PDOP"] = self.coordinator.data[self.id]["position"][0]["pdop"]
-                res["confidence"] = self.coordinator.data[self.id]["position"][0][
-                    "confidence"
-                ]
 
         return res

--- a/custom_components/weenect/device_tracker.py
+++ b/custom_components/weenect/device_tracker.py
@@ -178,7 +178,11 @@ class WeenectDeviceTracker(WeenectBaseEntity, TrackerEntity):
             if self.coordinator.data[self.id]["position"]:
                 return {
                     "speed": self.coordinator.data[self.id]["position"][0]["speed"],
-                    "course": self.coordinator.data[self.id]["position"][0]["direction"],
+                    "course": self.coordinator.data[self.id]["position"][0][
+                        "direction"
+                    ],
                     "PDOP": self.coordinator.data[self.id]["position"][0]["pdop"],
-                    "confidence": self.coordinator.data[self.id]["position"][0]["confidence"]
+                    "confidence": self.coordinator.data[self.id]["position"][0][
+                        "confidence"
+                    ],
                 }

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -34,6 +34,9 @@ async def test_device_tracker(hass):
     assert hass.states.get("device_tracker.test").attributes["latitude"] == 47.024191
     assert hass.states.get("device_tracker.test").attributes["gps_accuracy"] == 31
     assert hass.states.get("device_tracker.test").attributes["icon"] == "mdi:paw"
+    assert hass.states.get("device_tracker.test").attributes["speed"] == 4.8
+    assert hass.states.get("device_tracker.test").attributes["course"] == 312
+    assert hass.states.get("device_tracker.test").attributes["PDOP"] == 99.9
 
 
 @pytest.mark.usefixtures("get_trackers_not_a_pet_tracker")


### PR DESCRIPTION
Add 4 extra attributes to device tracker:

- speed
- course
- pdop (see https://en.wikipedia.org/wiki/Dilution_of_precision_(navigation))
- ~~confidence (GPS signal confidence)~~

Speed and course should be quite valuable since it allows HA to determine the direction of travel and speed. I'm not perfectly sure these are used for the [Proximity](https://www.home-assistant.io/integrations/proximity/) integration or if that is derived from the GPS location history. Since the HA mobile app is providing both attributes though and proximity sensors work very well with them, we should pass those attributes on from the Weenect API to HA.

PDOP and confidence on the other hand are for advanced users that want to dig deeper into GSM signal details. Basically they provide more detail on the GPS accuracy (when "number of GPS satellites" just isn't enough). I don't think it hurts to expose them via extra attributes. I didn't see them important enough to make dedicated sensors out of them though.