### PR TITLE
[fix] some sensors should be "unavailable" when the tracker is offline

### DIFF
--- a/custom_components/weenect/binary_sensor.py
+++ b/custom_components/weenect/binary_sensor.py
@@ -77,6 +77,8 @@ class WeenectBinarySensor(WeenectEntity, BinarySensorEntity):
     @property
     def available(self) -> bool:
         """Return if entity is available."""
+        if self.entity_description.key in ["valid_signal"]:
+            return super().available and bool(self.coordinator.data[self.id]["position"]) and bool(self.coordinator.data[self.id]["position"][0]["is_online"])
         return super().available and bool(self.coordinator.data[self.id]["position"])
 
     @property

--- a/custom_components/weenect/device_tracker.py
+++ b/custom_components/weenect/device_tracker.py
@@ -140,7 +140,7 @@ class WeenectDeviceTracker(WeenectBaseEntity, TrackerEntity):
     @property
     def available(self) -> bool:
         """Return if entity is available."""
-        return super().available and bool(self.coordinator.data[self.id]["position"])
+        return super().available and bool(self.coordinator.data[self.id]["position"]) and bool(self.coordinator.data[self.id]["position"][0]["is_online"])
 
     @property
     def latitude(self):

--- a/custom_components/weenect/sensor.py
+++ b/custom_components/weenect/sensor.py
@@ -230,6 +230,8 @@ class WeenectLocationSensor(WeenectSensor):
     @property
     def available(self) -> bool:
         """Return if entity is available."""
+        if self.entity_description.key in ["battery", "cellid", "gsm", "satellites"]:
+            return super().available and bool(self.coordinator.data[self.id]["position"]) and bool(self.coordinator.data[self.id]["position"][0]["is_online"])
         return super().available and bool(self.coordinator.data[self.id]["position"])
 
     @property


### PR DESCRIPTION
Following sensors IMHO should not retain their last value but rather show up as unavailable when the tracker itself is offline (either because it is turned off or because it has no reception):

- the device_tracker itself

**binary sensors**
- valid signal

**sensors**
- cell tower ID
- gsm strength
- GPS satellites
- battery

One could argue to let the battery retain its last state. IMHO it is better to indicate that the state is unclear. In the end the actual value could be far off from the last retained one. I'm not married to that idea though. The other sensors though definitely make no sense to expose when there's no signal.